### PR TITLE
bug/fixed-invalid-namespace-error-wmiobject-query

### DIFF
--- a/HostRecon.ps1
+++ b/HostRecon.ps1
@@ -187,23 +187,36 @@ function Invoke-HostRecon{
         }
     Write-Output "`n"
 
-    #Getting AntiVirus Information
+	#Getting AntiVirus Information
+	
 
+	Write-Output "[*] Checking if AV is installed"
+	
+	$AV = $null
+	$AVNamespaces = @(
+	    "root\SecurityCenter2",
+	    "root\SecurityCenter"
+	)
+	
+	foreach ($ns in $AVNamespaces) {
+	    try {
+	        $AV = Get-WmiObject -Namespace $ns -Query "SELECT * FROM AntiVirusProduct" -ErrorAction Stop
+	        if ($AV) { break }
+	    }
+	    catch {
+	        continue
+	    }
+	}
 
-    Write-Output "[*] Checking if AV is installed"
+	if ($AV) {
+	    Write-Output "The following AntiVirus product(s) appear to be installed:"
+	    $AV | Select-Object displayName, pathToSignedProductExe | Format-Table -AutoSize | Out-String
+	}
+	else {
+	    Write-Output "No AntiVirus product detected or access to SecurityCenter namespace denied."
+	}
 
-    $AV = Get-WmiObject -Namespace "root\SecurityCenter2" -Query "SELECT * FROM AntiVirusProduct" 
-
-    If ($AV -ne "")
-        {
-            Write-Output "The following AntiVirus product appears to be installed:" $AV.displayName
-        }
-    If ($AV -eq "")
-        {
-            Write-Output "No AV detected."
-        }
-    Write-Output "`n"
-
+	Write-Output "`n"
     #Getting Local Firewall Status
 
     Write-Output "[*] Checking local firewall status."


### PR DESCRIPTION
Added more robust checking for #Getting AntiVirus Information. Current version I was receiving this error when attempting to use this recon script:

```
[*] Checking if AV is installed
Get-WmiObject : Invalid namespace "root\SecurityCenter2"
At line:195 char:11
+     $AV = Get-WmiObject -Namespace "root\SecurityCenter2" -Query "SEL ...
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-WmiObject], ManagementException
    + FullyQualifiedErrorId : GetWMIManagementException,Microsoft.PowerShell.Commands.GetWmiObjectCommand
 
The following AntiVirus product appears to be installed:
```


With these changes, instead receive this:
```
[*] Checking if AV is installed
No AntiVirus product detected or access to SecurityCenter namespace denied.
```